### PR TITLE
Poprawa przykładu tworzenia AuthTokenRequest C#

### DIFF
--- a/uwierzytelnianie.md
+++ b/uwierzytelnianie.md
@@ -90,9 +90,9 @@ Przykład w języku C#:
 [KSeF.Client.Tests.Core\E2E\Authorization\AuthorizationE2ETests.cs](https://github.com/CIRFMF/ksef-client-csharp/blob/main/KSeF.Client.Tests.Core/E2E/Authorization/AuthorizationE2ETests.cs)
 
 ```csharp
-var authorizationPolicy = new AuthorizationPolicy
+var authorizationPolicy = new AuthenticationTokenAuthorizationPolicy
 {
-    AllowedIps = new AllowedIps
+    AllowedIps = new AuthenticationTokenAllowedIps
     {
         Ip4Addresses = ["192.168.0.1", "192.222.111.1"],
         Ip4Masks = ["192.168.1.0/24"], // Przykładowa maska


### PR DESCRIPTION
W najnowszej wersji nie ma takich klas. Zostały zastąpione przez nowe.