### PR TITLE
Zmiana dotnet SDK z 9 na 10 w podpisach XADES

### DIFF
--- a/auth/testowe-certyfikaty-i-podpisy-xades.md
+++ b/auth/testowe-certyfikaty-i-podpisy-xades.md
@@ -12,7 +12,7 @@ Ten przewodnik pokazuje, jak **szybko uruchomić** konsolową aplikację demonst
 ---
 
 ## Wymagania wstępne
-- **.NET 9 SDK**
+- **.NET 10 SDK**
 - Git
 - Windows lub Linux
 
@@ -31,9 +31,9 @@ Ten przewodnik pokazuje, jak **szybko uruchomić** konsolową aplikację demonst
 
 ## Windows
 
-1. **Zainstaluj .NET 9 SDK**:
+1. **Zainstaluj .NET 10 SDK**:
    ```powershell
-   winget install Microsoft.DotNet.SDK.9
+   winget install Microsoft.DotNet.SDK.10
    ```
    Alternatywnie: pobierz instalator z witryny .NET.
 
@@ -43,7 +43,7 @@ Ten przewodnik pokazuje, jak **szybko uruchomić** konsolową aplikację demonst
    ```powershell
    dotnet --version
    ```
-   Oczekiwany numer wersji: `9.x.x`.
+   Oczekiwany numer wersji: `10.x.x`.
 
 4. **Sklonuj repozytorium i przejdź do projektu**:
    ```powershell
@@ -53,7 +53,7 @@ Ten przewodnik pokazuje, jak **szybko uruchomić** konsolową aplikację demonst
 
 5. **Uruchom (domyślnie losowy NIP, wynik na ekranie)**:
    ```powershell
-   dotnet run --framework net9.0
+   dotnet run --framework net10.0
    ```
 
 6. **Uruchomienie z parametrami**:
@@ -62,7 +62,7 @@ Ten przewodnik pokazuje, jak **szybko uruchomić** konsolową aplikację demonst
    - opcjonalnie: `--no-startup-warnings`.
 
    ```powershell
-   dotnet run --framework net9.0 --output file --nip 8976111986 --no-startup-warnings
+   dotnet run --framework net10.0 --output file --nip 8976111986 --no-startup-warnings
    ```
 
 ---
@@ -76,9 +76,9 @@ Ten przewodnik pokazuje, jak **szybko uruchomić** konsolową aplikację demonst
    sudo apt-get update
    ```
 
-2. **Zainstaluj .NET 9 SDK**:
+2. **Zainstaluj .NET 10 SDK**:
    ```bash
-   sudo apt-get install -y dotnet-sdk-9.0
+   sudo apt-get install -y dotnet-sdk-10.0
    ```
 
 3. **Odśwież środowisko powłoki lub otwórz nowy terminal**:
@@ -90,7 +90,7 @@ Ten przewodnik pokazuje, jak **szybko uruchomić** konsolową aplikację demonst
    ```bash
    dotnet --version
    ```
-   Oczekiwany numer wersji: `9.x.x`.
+   Oczekiwany numer wersji: `10.x.x`.
 
 5. **Sklonuj repozytorium i przejdź do projektu**:
    ```bash
@@ -100,7 +100,7 @@ Ten przewodnik pokazuje, jak **szybko uruchomić** konsolową aplikację demonst
 
 6. **Uruchom (wynik na ekranie, losowy NIP)**:
    ```bash
-   dotnet run --framework net9.0
+   dotnet run --framework net10.0
    ```
 
 7. **Uruchomienie z parametrami**:
@@ -109,7 +109,7 @@ Ten przewodnik pokazuje, jak **szybko uruchomić** konsolową aplikację demonst
    - opcjonalnie: `--no-startup-warnings`.
 
    ```bash
-   dotnet run --framework net9.0 --output file --nip 8976111986 --no-startup-warnings
+   dotnet run --framework net10.0 --output file --nip 8976111986 --no-startup-warnings
    ```
 
 ---


### PR DESCRIPTION
Odniesienie do [issue 387](https://github.com/CIRFMF/ksef-client-csharp/issues/136).
Próba podążania komendami w tym pliku markdown zakończyła się niepowodzeniem.
Powodem było użycie SDK9

```sh
micha@DESKTOP-AGH5BIA MINGW64 ~/workspace/ksef-client-csharp/KSeF.Client.Tests.CertTestApp (main)
$ dotnet --version
9.0.308
[...dużo linii dalej...]
--------------------------------------------------------------------------------------
C:\Program Files\dotnet\sdk\9.0.308\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.TargetFrameworkInference.targets(166,5): error NETSDK1045: bieżący zestaw .NET SDK nie obsługuje wartości docelowej .NET 10.0. Użyj wartości docelowej .NET 9.0 lub niższej albo wersji zestawu .NET SDK obsługującej .NET 10.0. Pobierz zestaw .NET SDK z https://aka.ms/dotnet/download
C:\Program Files\dotnet\sdk\9.0.308\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.TargetFrameworkInference.targets(166,5): error NETSDK1045: bieżący zestaw .NET SDK nie obsługuje wartości docelowej .NET 10.0. Użyj wartości docelowej .NET 9.0 lub niższej albo wersji zestawu .NET SDK obsługującej .NET 10.0. Pobierz zestaw .NET SDK z https://aka.ms/dotnet/download
C:\Program Files\dotnet\sdk\9.0.308\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.TargetFrameworkInference.targets(166,5): error NETSDK1045: bieżący zestaw .NET SDK nie obsługuje wartości docelowej .NET 10.0. Użyj wartości docelowej .NET 9.0 lub niższej albo wersji zestawu .NET SDK obsługującej .NET 10.0. Pobierz zestaw .NET SDK z https://aka.ms/dotnet/download

Kompilacja nie powiodła się. Napraw błędy kompilacji i uruchom ją ponownie.
```

Po instalacji najnowszych i użyciu SDK w wersji 10 przykład działa super.

```sh
micha@DESKTOP-AGH5BIA MINGW64 ~/workspace/ksef-client-csharp/KSeF.Client.Tests.CertTestApp (main)
$ dotnet --version
10.0.100

micha@DESKTOP-AGH5BIA MINGW64 ~/workspace/ksef-client-csharp/KSeF.Client.Tests.CertTestApp (main)
$ dotnet run --framework net10.0
KSeF.Client.Tests.CertTestApp – demonstracja procesu uwierzytelnienia XAdES
Tryb wyjścia: screen
[1] Przygotowanie NIP...
    NIP: 6844979405 (losowy)

[... dużo linii dalej...]

[7] Wysyłanie podpisanego XML do KSeF...
    ReferenceNumber: 20251122-AU-1940318000-8FBBCAC104-A3
[8] Odpytanie o status operacji uwierzytelnienia...
      Status: 200 - Uwierzytelnianie zakończone sukcesem | upłynęło: 00:00
[9] Pobieranie access token...
    AccessToken: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0eXAiOiJDb250ZXh0VG9rZW4iLCJjaXQiOiJOaXAiLCJjaXYiOiI2ODQ0OTc5NDA1IiwiYXVtIjoiUXVhbGlmaWVkU2lnbmF0dXJlIiwiYXJuIjoiMjAyNTExMjItQVUtMTk0MDMxODAwMC04RkJCQ0FDMTA0LUEzIiwic3VkIjoie1wic3ViamVjdElkZW50aWZpZXJcIjp7XCJ0eXBlXCI6XCJOaXBcIixcInZhbHVlXCI6XCI2ODQ0OTc5NDA1XCJ9LFwiZ2l2ZW5OYW1lXCI6XCJBXCIsXCJzdXJuYW1lXCI6XCJSXCIsXCJzZXJpYWxOdW1iZXJcIjpcIlRJTlBMLTY4NDQ5Nzk0MDVcIixcImNvbW1vbk5hbWVcIjpcIkEgUlwiLFwiY291bnRyeU5hbWVcIjpcIlBMXCJ9IiwicGVyIjoiW1wiT3duZXJcIl0iLCJwZWMiOiJbXSIsInJvbCI6IltdIiwicGVwIjoiW10iLCJpb3AiOiJbXSIsImV4cCI6MTc2Mzc5Njk3NywiaWF0IjoxNzYzNzk2MDc3LCJpc3MiOiJrc2VmLWFwaS10ZSIsImF1ZCI6ImtzZWYtYXBpLXRlIn0.aRKVrqtyfkZH37IKO3J24L_sQWPEDRoSRo8_2GUiXWE
    RefreshToken: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0eXAiOiJSZWZyZXNoVG9rZW4iLCJhcm4iOiIyMDI1MTEyMi1BVS0xOTQwMzE4MDAwLThGQkJDQUMxMDQtQTMiLCJleHAiOjE3NjQ0MDA4NzcsImlhdCI6MTc2Mzc5NjA3NywiaXNzIjoia3NlZi1hcGktdGUiLCJhdWQiOiJrc2VmLWFwaS10ZSJ9.PCoYwO4oXL4kZUgM5otwwvYFQ9y2RVqqMVd1ZAsRa5M
Zakończono pomyślnie.
```

Źródła sprawdzone podczas odświeżania dokumentacji buildu:
[Linux](https://learn.microsoft.com/pl-pl/dotnet/core/install/linux-debian?tabs=dotnet10)
[Windows (winget)](https://learn.microsoft.com/pl-pl/dotnet/core/install/windows?WT.mc_id=dotnet-35129-website#install-with-windows-package-manager-winget)