### PR TITLE
Klaryfikacja budowania `encryptedToken` z tokena i timestampa.

### DIFF
--- a/open-api.json
+++ b/open-api.json
@@ -7450,7 +7450,7 @@
           "Uzyskiwanie dostępu"
         ],
         "summary": "Uwierzytelnienie z wykorzystaniem tokena KSeF",
-        "description": "Rozpoczyna operację uwierzytelniania z wykorzystaniem wcześniej wygenerowanego tokena KSeF.\n\nToken KSeF wraz z timestampem ze wcześniej wygenerowanego challenge'a (w formacie ```token|timestamp```) powinien zostać zaszyfrowany dedykowanym do tego celu kluczem publicznym.\n- Timestamp powinien zostać przekazany jako **liczba milisekund od 1 stycznia 1970 roku (Unix timestamp)**.\n- Algorytm szyfrowania: **RSA-OAEP (z użyciem SHA-256 jako funkcji skrótu)**.\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).",
+        "description": "Rozpoczyna operację uwierzytelniania z wykorzystaniem wcześniej wygenerowanego tokena KSeF.\n\nToken KSeF wraz z timestampem ze wcześniej wygenerowanego challenge'a (w formacie ```token|timestampMs```) powinien zostać zaszyfrowany dedykowanym do tego celu kluczem publicznym.\n- Timestamp powinien zostać przekazany jako **liczba milisekund od 1 stycznia 1970 roku (Unix timestamp)**.\n- Algorytm szyfrowania: **RSA-OAEP (z użyciem SHA-256 jako funkcji skrótu)**.\n\n**Headers:**\n\n`X-Error-Format: problem-details` - ustawienie tego nagłówka powoduje zwracanie błędów w formacie **Problem Details** (`application/problem+json`).",
         "requestBody": {
           "content": {
             "application/json": {
@@ -10340,7 +10340,7 @@
           },
           "timestampMs": {
             "type": "integer",
-            "description": "Czas wygenerowania challenge-a w milisekundach od 1 stycznia 1970 roku (Unix timestamp).",
+            "description": "Czas wygenerowania challenge-a w milisekundach od 1 stycznia 1970 roku (Unix timestamp). Potrzebny do zbudowania `encryptedToken`.",
             "format": "int64"
           },
           "clientIp": {
@@ -13448,7 +13448,7 @@
           },
           "encryptedToken": {
             "type": "string",
-            "description": "Zaszyfrowany token wraz z timestampem z challenge'a, w postaci `token|timestamp`, zakodowany w formacie Base64.",
+            "description": "Zaszyfrowany token wraz z timestampem z challenge'a, w postaci `token|timestampMs`, zakodowany w formacie Base64.",
             "format": "byte"
           },
           "publicKeyId": {


### PR DESCRIPTION
Problem wykryty podczas pracy nad https://github.com/coffee-software/ksef

Aktualny opis pola `encryptedToken` z `/auth/ksef-token`:

> Zaszyfrowany token wraz z timestampem z challenge'a, w postaci `token|timestamp`, zakodowany w formacie Base64.

Opis endpointu definiuje wprawdzie że timestamp to "liczba milisekund od 1 stycznia 1970 roku (Unix timestamp)", jednak użyta tutaj nazwa `timestamp` niefortunnie zbiega się z polem `timestamp` zwracanym z challenga i może to sugerować użycie tutaj stringa.

Problem udało się zdiagnozować dopiero po analizie kodu oficjalnych bibliotek, co ciekawe np `ksef-client-csharp` parsuje tutaj pole `timestamp` i zamienia je na unix timestamp (zamiast wykorzystać `timestampMs`). Daje to oczywiście taki sam wynik ale wygląda jak niepotrzebne operacje po stronie klienta.

https://github.com/CIRFMF/ksef-client-csharp/blob/9362cc578739ccd4c0b96c3e597b93184dfb8966/KSeF.Client/Api/Services/AuthCoordinator.cs#L33

Rodzi to również pytanie czy pole `timestamp` jest w ogóle do czegoś potrzebne poza kompatybilnością wsteczną. Być może warto oznaczyć to pole jako deprecated?